### PR TITLE
Add support for dynamic tracking.

### DIFF
--- a/addon/services/geolocation.js
+++ b/addon/services/geolocation.js
@@ -2,39 +2,64 @@ import Ember from 'ember';
 
 export default Ember.Service.extend(Ember.Evented, {
 
+  geolocator: Ember.computed(() => {
+    return window.navigator.geolocation;
+  }),
+
+  _handleNewPosition(geoObject) {
+      this.set('currentLocation', [geoObject.coords.latitude, geoObject.coords.longitude]);
+      const callback = this.get('trackingCallback');
+      if (callback) {
+        callback(geoObject);
+      }
+      this.trigger('geolocationSuccess', geoObject);
+  },
+
   currentLocation: null,
 
   getLocation(geoOptions) {
-
     return new Ember.RSVP.Promise((resolve, reject) => {
-      navigator.geolocation.getCurrentPosition((geoObject) => {
-        this.trigger('geolocationSuccess', geoObject, resolve);
+      this.get('geolocator').getCurrentPosition((geoObject) => {
+        this._handleNewPosition(geoObject);
+        resolve(geoObject);
       }, (reason) => {
-        this.trigger('geolocationFail', reason, reject);
+        this.trigger('geolocationFail', reason);
+        reject(reason);
       }, geoOptions);
     });
-
   },
 
-  trackLocation(geoOptions) {
+  trackLocation(geoOptions, callback) {
+    let watcherId = this.get('watcherId');
+
+    Ember.assert(watcherId == null, 'Warning: `trackLocation` was called but a tracker is already set');
+
+    if (callback != null) {
+      Ember.assert(typeof callback === 'function', "callback should be a function");
+    }
+    this.set('trackingCallback', callback);
 
     return new Ember.RSVP.Promise((resolve, reject) => {
-      navigator.geolocation.watchPosition((geoObject) => {
-        this.trigger('geolocationSuccess', geoObject, resolve);
+      let watcherId = this.get('geolocator').watchPosition((geoObject) => {
+        // make sure this logic is run only once
+        if (resolve) {
+          this.set('watcherId', watcherId);
+          resolve(geoObject);
+          resolve = null;
+        }
+        this._handleNewPosition(geoObject);
       }, (reason) => {
-        this.trigger('geolocationFail', reason, reject);
+        this.trigger('geolocationFail', reason);
+        reject(reason);
       }, geoOptions);
     });
-
   },
 
-  geolocationDidSucceed: Ember.on('geolocationSuccess', function(geoObject, resolve) {
-    this.set('currentLocation', [geoObject.coords.latitude, geoObject.coords.longitude]);
-    resolve(geoObject);
-  }),
-
-  geolocationDidFail: Ember.on('geolocationFail', function(reason, reject) {
-    reject(reason);
-  })
+  stopTracking() {
+    let watcher = this.get('watcherId');
+    Ember.assert(watcher != null, 'Warning: `stopTracking` was called but location isn\'t tracked');
+    this.get('geolocator').clearWatch(watcher);
+    this.set('watcherId', null);
+  },
 
 });

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "ember": "~2.5.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
-    "mocha": "~2.2.4",
+    "mocha": "~3.0.2",
     "chai": "~2.3.0",
     "ember-mocha-adapter": "~0.3.1"
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-export-application-global": "^1.0.4",
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "^0.5.1",
     "ember-try": "^0.1.2",
     "loader.js": "^4.0.0"
   },


### PR DESCRIPTION
API was maintained. Promises only resolve once, no longer attempting to
resolve for each callback sent by the browser event loop for location
tracked.
Add support for registering callbacks.
Update tests. Add sinon and test interaction with geolocation object in
the browser.