### PR TITLE
Update description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Code Climate](https://codeclimate.com/github/igorpreston/ember-cli-geo/badges/gpa.svg)](https://codeclimate.com/github/igorpreston/ember-cli-geo) [![Build Status](https://travis-ci.org/igorpreston/ember-cli-geo.svg)](https://travis-ci.org/igorpreston/ember-cli-geo)
 
 This addon is a go-to solution for integrating HTML5 Geolocation API into your Ember.js web app.
-It is production-ready and is actively used in my own real-world web apps.
+It is production-ready and backwards compatible.
 
 
 ## Installation
@@ -15,32 +15,53 @@ ember install ember-cli-geo
 #### getLocation()
 `getLocation()` gets user location from the browser and writes its coordinates to `currentLocation` property on the service. Accepts __geoOptions__ as an argument. Returns an __Ember.RSVP.Promise__ which is either resolved with __geoObject__ containing all data about user location or is rejected with __reason__ which explains why geolocation failed.
 It is used like this:
-```
+```js
 this.get('geolocation').getLocation().then(function(geoObject) {
   // do anything with geoObject here
   // you can also access currentLocation property and manipulate its data however you like
 });
 ```
 It corresponds to _getCurrentPosition() in HTML5 Geolocation API_. Learn more at [getCurentPosition() on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/getCurrentPosition).
+It emits an event `geolocationSuccess` with an object describing the geolocation when the position is available. If it fails, it emits an event `geolocationFail` with a reason.
 #### trackLocation()
-`trackLocation()` gets user location and setups a watcher which observes any changes occuring to user location. It then constantly updates `currentLocation` with the most recent location coordinates. Accepts __geoOptions__ as an argument. Returns an __Ember.RSVP.Promise__ which is either resolved with __geoObject__ containing all data about user location or is rejected with __reason__ which explains why geolocation failed.
+`trackLocation()` gets user location and setups a watcher which observes any changes occuring to user location. It then constantly updates `currentLocation` with the most recent location coordinates. 
+
+It accepts __geoOptions__ as an argument. Returns an __Ember.RSVP.Promise__ which is either resolved with __geoObject__ containing all data about user location or is rejected with __reason__ which explains why geolocation failed.
+It accepts an optional __callback__ function, that is called whenever the position is updated.
+It emits an event `geolocationSuccess` with an object describing the geolocation whenever a new position is available. If it fails, it emits an event `geolocationFail` with a reason.
+
 It is used like this:
-```
+```js
 this.get('geolocation').trackLocation().then(function(geoObject) {
   // do anything with geoObject here
   // currentLocation is constantly updated if user location is changed
 });
+// or
+this.get('geolocation').trackLocation(null, (geoObject) => { /* will be called with new positiond */ })
+// or
+const service = this.get('geolocation');
+service.on('geolocationSuccess', (geoObject) => { { /* will be called with new position */);
 ```
 It corresponds to _watchPosition() in HTML5 Geolocation API_. Learn more at [watchPosition() on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/watchPosition).
+#### stopTracking
+`stopTracking()` stops the app from continuously updating the user location. 
+
+It accepts an optional boolean parameter that clears `currentLocation` if it's true.
+
+It is used like this:
+```js
+this.get('geolocation').stopTracking(true);
+```
+It corresponds to _watchPosition() in HTML5 Geolocation API_. Learn more at [clearWatch() on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/clearWatch).
 #### currentLocation
 `currentLocation` is a property of geolocation service which stores the __array__ of user location coordinates in the format of __[lat, lon]__.
 It is used like this:
-```
+```js
 this.get('geolocation').get('currentLocation');
 ```
 #### geoObject
 `geoObject` is an object which contains all data about user location. Both `getLocation()` and `trackLocation()` promises are resolved with it. It looks like this:
-```
+```js
 {
   coords: {
     accuracy: 100,
@@ -60,7 +81,7 @@ It corresponds to _Position object in HTML5 Geolocation API_. Learn more at [Pos
 It corresponds to _PositionError object in HTML5 Geolocation API_. Learn more at [PositionError object on MDN](https://developer.mozilla.org/en-US/docs/Web/API/PositionError).
 #### geoOptions
 `geoOptions` is an optional object that can be passed to both `getLocation()` and `trackLocation()` to customize geolocation query. If you didn't pass it to functions, then next defaults will be automatically passed:
-```
+```js
 {
   enableHighAccuracy: false,
   timeout: Infinity,
@@ -72,7 +93,7 @@ It corresponds to _PositionOptions object in HMTL5 Geolocation API_. Learn more 
 
 #### Setup geolocation service
 In order to use geolocation inside of your _Ember.Route_ you should directly inject it to the one:
-```
+```js
 export default Ember.Route.extend({
   geolocation: Ember.inject.service()
 });
@@ -81,7 +102,7 @@ export default Ember.Route.extend({
 #### Get user location and display it in your template
 You need to implement a custom action which will call the geolocation service.
 In your route:
-```
+```js
 // app/routes/geolocator.js
 
 export default Ember.Route.extend({
@@ -98,7 +119,7 @@ export default Ember.Route.extend({
 ```
 
 In your controller:
-```
+```js
 // app/controllers/geolocator.js
 
 export default Ember.Controller.extend({
@@ -107,7 +128,7 @@ export default Ember.Controller.extend({
 ```
 
 In your template:
-```
+```js
 // app/templates/geolocator.hbs
 
 <button type="button" {{action 'getUserLocation'}}>Geolocate me!</button>

--- a/addon/services/geolocation.js
+++ b/addon/services/geolocation.js
@@ -55,11 +55,14 @@ export default Ember.Service.extend(Ember.Evented, {
     });
   },
 
-  stopTracking() {
+  stopTracking(clearLocation) {
     let watcher = this.get('watcherId');
     Ember.assert(watcher != null, 'Warning: `stopTracking` was called but location isn\'t tracked');
     this.get('geolocator').clearWatch(watcher);
     this.set('watcherId', null);
+    if (clearLocation === true) {
+        this.set('currentLocation', null);
+    }
   },
 
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-geo",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Geolocation service for Ember.js web apps",
   "directories": {
     "doc": "doc",
@@ -22,7 +22,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-ajax": "0.7.1",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
@@ -34,7 +33,6 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.5.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",

--- a/tests/unit/services/geolocation-test.js
+++ b/tests/unit/services/geolocation-test.js
@@ -128,6 +128,16 @@ describeModule(
         expect(spy.calledOnce).to.equal(true, '#clearWatch should be called on browser geolocation');
       });
 
+      it('#stopTracking can clear currentLocation', function() {
+        const service = this.subject();
+        let spy = sandbox.spy(window.navigator.geolocation, 'clearWatch');
+
+        service.stopTracking(true);
+
+        expect(spy.calledOnce).to.equal(true, '#clearWatch should be called on browser geolocation');
+        expect(service.get('currentLocation')).to.equal(null, 'currentLocation should be cleared');
+      });
+
       it('fails if the browser cannot provide location', function(done) {
         const service = this.subject();
         let successCbCalled = false;


### PR DESCRIPTION
Bump up version to 3.0.0 so it gets picked up by `npm install`.
Add support for clearing the `currentLocation` from the service based on
a parameter when `stopTracking` is called.