### PR TITLE
Remove project.nodeModulesPath DEPRECATION warning on ember 2.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.4",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-mocha": "0.10.1",
@@ -49,7 +49,7 @@
     "geoservice"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^6.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
fix #14 

Depend on "ember-cli-babel": "^6.2.0" to remove the dep on ember-cli-version-checker@1.3.1